### PR TITLE
softdelete || novo endpoint para tarefas deletadas

### DIFF
--- a/src/app/todo.controller.spec.ts
+++ b/src/app/todo.controller.spec.ts
@@ -138,7 +138,7 @@ describe('TodoController', () => {
 		});
 
 		it('should throw an exception', () => {
-			jest.spyOn(todoService, 'deleteById').mockRejectedValue(new Error());
+			jest.spyOn(todoService, 'softDeleteById').mockRejectedValue(new Error());
 
 			expect(todoController.destroy('1')).rejects.toThrow();
 		});

--- a/src/app/todo.controller.ts
+++ b/src/app/todo.controller.ts
@@ -39,6 +39,18 @@ export class TodoController {
 		return await this.todoService.findAll();
 	}
 
+	@Get('deleted')
+	@ApiOperation({ summary: 'Listar todas as tarefas deletadas' })
+	@ApiResponse({
+		status: 200,
+		description: 'Lista de tarefas deletadas',
+		type: IndexTodoSwagger,
+		isArray: true,
+	})
+	async getDeleted() {
+		return await this.todoService.findAllDeleted();
+	}
+
 	@Post()
 	@ApiResponse({ status: 201, description: 'Criado', type: CreateTodoSwagger })
 	@ApiResponse({
@@ -101,6 +113,6 @@ export class TodoController {
 	@ApiOperation({ summary: 'Excluir uma tarefa' })
 	@HttpCode(HttpStatus.NO_CONTENT)
 	async destroy(@Param('id', new ParseUUIDPipe()) id: string) {
-		return await this.todoService.deleteById(id);
+		return await this.todoService.softDeleteById(id);
 	}
 }

--- a/src/app/todo.service.ts
+++ b/src/app/todo.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
-import { Repository } from 'typeorm';
+import { IsNull, Not, Repository } from 'typeorm';
 import { TodoEntity } from './todo/entity/todo.entity';
 import { InjectRepository } from '@nestjs/typeorm';
 import { CreateTodoDto } from './todo/dto/create-todo.dto';
@@ -14,6 +14,15 @@ export class TodoService {
 
 	async findAll() {
 		return await this.todoRepository.find();
+	}
+
+	async findAllDeleted() {
+		return await this.todoRepository.find({
+            withDeleted: true,
+            where: {
+                deletedAt: Not(IsNull()),
+            }
+        });
 	}
 
 	async findOneOrFail(id: string) {
@@ -32,10 +41,8 @@ export class TodoService {
 		return await this.todoRepository.save(todo);
 	}
 
-	async deleteById(id: string) {
-		const todo = await this.findOneOrFail(id);
-		todo.deletedAt = new Date();
-		return await this.todoRepository.save(todo);
+	async softDeleteById(id: string) {
+        return this.todoRepository.softDelete(id);
 	}
 
 	async update(id: string, data: UpdateTodoDto) {

--- a/src/app/todo/entity/todo.entity.ts
+++ b/src/app/todo/entity/todo.entity.ts
@@ -2,6 +2,7 @@ import { ApiProperty } from '@nestjs/swagger';
 import {
 	Column,
 	CreateDateColumn,
+	DeleteDateColumn,
 	Entity,
 	PrimaryGeneratedColumn,
 	UpdateDateColumn,
@@ -36,6 +37,7 @@ export class TodoEntity {
 		default: null,
 	})
 	@ApiProperty()
+    @DeleteDateColumn()
 	deletedAt: Date | null;
 
 	constructor(todo?: Partial<TodoEntity>) {


### PR DESCRIPTION
Falai pett.. conforme combinamos, aqui vai um sumário das mudanças desse PR:

- Adicionando softdelete ao invés do delete atualizando o campo "deleted_at" da entidade todo (isso já faz com que na hora de buscar as listas esses itens deletados não voltem junto)
- Adicionando novoendpoint para pegar somente os valores deletados

Segue um vídeo mostrando as novas funcionalidades:
https://github.com/user-attachments/assets/46be51f4-8930-44f7-971d-80a8075e1d0e

